### PR TITLE
Fix for unmatching comments @ README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ app.enable('trust proxy'); // only if you're behind a reverse proxy (Heroku, Blu
 
 const speedLimiter = slowDown({
   windowMs: 15*60*1000, // 15 minutes
-  delayAfter: 100 // allow 100 requests per 10 minutes, then...
+  delayAfter: 100 // allow 100 requests per 15 minutes, then...
   delayMs: 500 // begin adding 500ms of delay per request above 100:
   // request # 101 is delayed by  500ms
   // request # 102 is delayed by 1000ms
-  // request # 103 is delayed bu 1500ms
+  // request # 103 is delayed by 1500ms
   // etc.
 });
 


### PR DESCRIPTION
A comment didn't make sense because it reflected different numbers compared to the applied logic. Fixed.

Also, fixed a typo.