### PR TITLE
bug fixed with hits variable 

### DIFF
--- a/lib/memory-store.js
+++ b/lib/memory-store.js
@@ -7,38 +7,38 @@ function calculateNextResetTime(windowMs) {
 }
 
 function MemoryStore(windowMs) {
-  let hits = {};
+  !global._hits && (global._hits = {});
   let resetTime = calculateNextResetTime(windowMs);
 
   this.incr = function (key, cb) {
-    if (hits[key]) {
-      hits[key]++;
+    if (global._hits[key]) {
+      global._hits[key]++;
     } else {
-      hits[key] = 1;
+      global._hits[key] = 1;
     }
 
-    cb(null, hits[key], resetTime);
+    cb(null, global._hits[key], resetTime);
   };
 
   this.decrement = function (key) {
-    if (hits[key]) {
-      hits[key]--;
+    if (global._hits[key]) {
+      global._hits[key]--;
     }
   };
 
-  // export an API to allow hits all IPs to be reset
+  // export an API to allow global._hits all IPs to be reset
   this.resetAll = function () {
-    hits = {};
+    global._hits = {};
     resetTime = calculateNextResetTime(windowMs);
   };
 
-  // export an API to allow hits from one IP to be reset
+  // export an API to allow global._hits from one IP to be reset
   this.resetKey = function (key) {
-    delete hits[key];
+    delete global._hits[key];
     delete resetTime[key];
   };
 
-  // simply reset ALL hits every windowMs
+  // simply reset ALL global._hits every windowMs
   const interval = setInterval(this.resetAll, windowMs);
   if (interval.unref) {
     interval.unref();


### PR DESCRIPTION
`const slowDown =  require("express-slow-down");
function otherMiddleware(req,res,next){ 
const limiter  = slowDown() ; return limiter(req,res,next); 
}`
 when calling  middleware inside other middleware the hits variable is being rested every time and never counts the requests of  specific key and this causes the limiter malfunction.