### PR TITLE
Feature addition request : onMaxDelayReached -  add onMaxDelayReached call back, test and readme notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ A `req.slowDown` property is added to all requests with the following fields:
   }
   ```
 
+- **onMaxDelayReached**: middleware called after delay reached maxDelay for a specific window.
+  only work if maxDelayMs is set . this function usefull to avoid case after reaching maxDelay all request 
+  gets same delsy time and invoked togheter. Defaults:
+  ```js
+
+  function (req, res) {
+  /* empty */
+  }
+  ```
 - **store**: The storage to use when persisting rate limit attempts. By default, the [MemoryStore](lib/memory-store.js) is used.
   - Note: when using express-slow-down and express-rate-limit with an external store, you'll need to create two instances of the store and provide different prefixes so that they don't double-count requests.
 - **headers**: Add `X-SlowDown-Limit`, `X-SlowDown-Remaining`, and if the store supports it, `X-SlowDown-Reset` headers to all responses. Modeled after the equivalent headers in express-rate-limit. Default: `false`

--- a/lib/express-slow-down.js
+++ b/lib/express-slow-down.js
@@ -20,6 +20,7 @@ function SlowDown(options) {
       return false;
     },
     onLimitReached: function (/*req, res, optionsUsed*/) {},
+    onMaxDelayReached: function (/*req, res, optionsUsed*/) {},
   });
 
   // store to use for persisting rate limit data
@@ -57,6 +58,14 @@ function SlowDown(options) {
       if (current > delayAfter) {
         const unboundedDelay = (current - delayAfter) * options.delayMs;
         delay = Math.min(unboundedDelay, options.maxDelayMs);
+      }
+
+      if (
+        options.maxDelayMs &&
+        options.onMaxDelayReached &&
+        delay === options.maxDelayMs
+      ) {
+        options.onMaxDelayReached(req, res);
       }
 
       req.slowDown = {

--- a/test/express-slow-down-test.js
+++ b/test/express-slow-down-test.js
@@ -576,6 +576,21 @@ describe("express-slow-down node module", function () {
         },
       })
     );
+    fastRequest(done);
+    fastRequest(done);
+  });
+
+  it("should call on onMaxDelayReached function after delay pass limit max delay", function (done) {
+    createAppWith(
+      slowDown({
+        delayAfter: 0,
+        delayMs: 100,
+        maxDelayMs: 200,
+        onMaxDelayReached: function () {
+          done();
+        },
+      })
+    );
     fastRequest();
     fastRequest();
   });
@@ -586,7 +601,7 @@ describe("express-slow-down node module", function () {
         delayAfter: 0,
         delayMs: 100,
         onMaxDelayReached: function () {
-          done(new Error());
+          done(new Error("onMaxDelayReached was called unexpectedly"));
         },
       })
     );

--- a/test/express-slow-down-test.js
+++ b/test/express-slow-down-test.js
@@ -564,4 +564,34 @@ describe("express-slow-down node module", function () {
         }
       });
   });
+
+  it("should call on onMaxDelayReached function after delay pass limit max delay", function (done) {
+    createAppWith(
+      slowDown({
+        delayAfter: 0,
+        delayMs: 100,
+        maxDelayMs: 200,
+        onMaxDelayReached: function () {
+          done();
+        },
+      })
+    );
+    fastRequest();
+    fastRequest();
+  });
+
+  it("onMaxDelayReached should not be called without maxDelayMs parameter been set", function (done) {
+    createAppWith(
+      slowDown({
+        delayAfter: 0,
+        delayMs: 100,
+        onMaxDelayReached: function () {
+          done(new Error());
+        },
+      })
+    );
+    fastRequest();
+    fastRequest();
+    done();
+  });
 });


### PR DESCRIPTION
please consider adding this feature  - a callback function that is used when MaxDelayReached has been reached 

our project is behind a Load balancer with an idle timeout of 2 minutes 
we notice that in some cases the SetTimeout inside the slow-down-rate limit is executing after the connection is disconnected.
and there is no way to access the Timer Ref to clear it.

also another issue 

From the readme example today the behavior is 
```

// Example

// Given:
{
    delayAfter: 1,
    delayMs: 1000,
    maxDelayMs: 20000,
}

// Results will be:
// 1st request - no delay
// 2nd request - 1000ms delay
// 3rd request - 2000ms delay
// 4th request - 3000ms delay
// ...
// 20th request - 19000ms delay
// 21st request - 20000ms delay
// 22nd request - 20000ms delay
// 23rd request - 20000ms delay
// 24th request - 20000ms delay <-- will not increase past 20000ms
// ...
```
so after reaching 20000 there is a potential of a large amount of requests 
Served together  in case someone will change the idle time at the load balance 
if you add the new functionality you can avoid this. 

Also it is very useful  if you want to block requests when slow-down-limitter reach maxDelay 

I really love your work and don't want to use my own fork. 
I didn't see you got here any contribution guide so I just follow linting rules 

**add implementation:**
```
if (
        options.maxDelayMs &&
        options.onMaxDelayReached &&
        delay === options.maxDelayMs
      ) {
        options.onMaxDelayReached(req, res);
      }

```
 **add these 2 specs to the test file** 
- `onMaxDelayReached should not be called without maxDelayMs parameter being set`
- `should call on onMaxDelayReached function after delay pass limit max delay `

 **update README file** 

If my PR needs any changes or updates, I will be happy to work on it.


-----------------------------------------------------------------------------------------------------------


Note: Another suggestion if you don't want to add this functionality 
it will be nice if we can disable the timer in case the request disconnected 

today in our project  we solving this issue by wrapping the slowDown middleware 
then the `blockeTimer` function will be executed after the timeout in if the connection is closed we don't executing the next middleware

```

import slowDown from 'express-slow-down';

function createSlowDownMiddleware(req, res, next) {
    const slowDownHandler = slowDown({...});
    let shouldBlockRequest = false;
    req.on('close', function () {
        shouldBlockRequest = true;
    });
    req.on('end', function () {
        shouldBlockRequest = true;
    });
    const nextMiddleWare = next

    const blockeTimer = (req, res, next) => {
        if (shouldBlockRequest) res.send('diconnected ')
        else nextMiddleWare()
    }
    return slowDownHandler(req, res, blockeTimer)

}
```

thanks!